### PR TITLE
Messy hack that removes navigation slowdowns and solarized theme locking up helm

### DIFF
--- a/lsp-ui-doc.el
+++ b/lsp-ui-doc.el
@@ -300,7 +300,7 @@ BUFFER is the buffer where the request has been made."
   (when (lsp-ui-doc--get-frame)
     (lsp-ui-doc--with-buffer
      (erase-buffer))
-    (make-frame-invisible (lsp-ui-doc--get-frame))))
+    (lsp-ui-doc--delete-frame)))
 
 (defun lsp-ui-doc--buffer-width ()
   "Calcul the max width of the buffer."


### PR DESCRIPTION
This fixes issue #33 and slowdown during buffer navigation after the first display of the documentation frame. However, it forces the documentation frame to be recreated whenever it is displayed.